### PR TITLE
fix(sync): guard against parser errors in UDP message listener

### DIFF
--- a/src/NtpTimeSync.ts
+++ b/src/NtpTimeSync.ts
@@ -385,8 +385,17 @@ export class NtpTimeSync {
           timeoutHandler = null;
           client.close();
 
+          let parsed: Partial<NtpPacket>;
+          try {
+            parsed = NtpPacketParser.parse(msg);
+          } catch (err) {
+            hasFinished = true;
+            reject(err);
+            return;
+          }
+
           const result: NtpReceivedPacket = {
-            ...NtpPacketParser.parse(msg),
+            ...parsed,
             destinationTimestamp: new Date(),
           };
 


### PR DESCRIPTION
## Summary

- Wrap `NtpPacketParser.parse()` inside the dgram `"message"` listener in a try/catch so a parse failure rejects the pending promise cleanly instead of escaping the callback.
- No dependency bump: `ntp-packet-parser` stays at `^0.5.0`. This is the consumer-side guard, landed independently ahead of the parser's input-validation change.
- On parse failure the listener now sets `hasFinished = true` and calls `reject(err)`, preserving the existing invariants around `hasFinished`, `timeoutHandler`, and `client.close()`.

## Context

An upcoming `ntp-packet-parser` release will add input validation to `NtpPacketParser.parse()` — it will throw `TypeError` on non-48-byte inputs or non-`Buffer` arguments. Without this guard, that throw would escape the dgram listener callback and surface as `uncaughtException` on the Node process. Worse, because the listener is the only path that clears `timeoutHandler` / sets `hasFinished`, the outer promise would hang until `replyTimeout` fires — and on Node processes without a global `uncaughtException` handler, the process would crash outright.

With this guard, a malformed UDP response produces a rejected promise that the existing retry loop in `collectSamples` already handles (it catches via `.catch((e) => e)` and filters `Error` results out of `ntpResults`).

## Test plan

There are no existing tests in this repo, so `yarn build` (tsc) is the only automated gate, and it passes.

Manual repro against a local UDP server that returns a malformed response:

```js
const dgram = require("dgram");
const server = dgram.createSocket("udp4");
server.on("message", (_, rinfo) =>
  server.send(Buffer.from("short"), rinfo.port, rinfo.address));
server.bind(1234);
// Then call new NtpTimeSync({...}).getTime() pointed at 127.0.0.1:1234.
// Before: uncaughtException + promise hang. After: promise rejects cleanly.
```

## Note

This PR intentionally does NOT bump the `ntp-packet-parser` dependency. The parser-side change (input validation) will land in a separate release; this consumer-side guard is defensive and safe to ship first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)