### PR TITLE
ci: bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,9 @@ jobs:
       contents: read
       security-events: write
 
+    env:
+      CODEQL_ACTION_FILE_COVERAGE_ON_PRS: true
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         node-version: ['20', '22', '24', '25']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
       - name: Cache Node.js modules
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}
@@ -39,15 +39,15 @@ jobs:
       matrix:
         node-version: ['20', '22', '24', '25']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
       - name: Cache Node.js modules
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}-deno

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,8 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         node-version: ['22']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
       - name: Cache Node.js modules
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}


### PR DESCRIPTION
## Summary

Upgrade JavaScript-based GitHub Actions to majors that run on the Node.js 24 runtime. This resolves two GitHub deprecation warnings currently surfacing in CI:

1. **Node.js 20 JavaScript actions deprecation** — older `v4` majors of the core `actions/*` are built against the deprecated Node.js 20 runtime.
2. **CodeQL Action v3 deprecation** — `github/codeql-action/*@v3` has been superseded by `@v4`.

### Action version bumps

- `actions/checkout@v4` -> `@v5`
- `actions/setup-node@v4` -> `@v5`
- `actions/cache@v4` -> `@v5`
- `github/codeql-action/{init,autobuild,analyze}@v3` -> `@v4`
- Plus two stale `@v2` pins in `npm-release.yml` bumped to current majors

Files touched: `.github/workflows/{prettier,codeql-analysis,nodejs,npm-release}.yml`.

## Test plan

- [x] `nodejs.yml` build matrix passes on all Node versions (20/22/24/25)
- [x] `codeql-analysis.yml` completes scan successfully on the new `@v4` actions
- [x] `prettier.yml` format check passes
- [x] `npm-release.yml` workflow YAML is valid (dry-run via GitHub Actions parser on push)
- [x] No new deprecation warnings appear in the Actions logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)