### PR TITLE
chore: Remove unnecessary files from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,7 @@
     "url": "https://github.com/buffcode/ntp-time-sync.git"
   },
   "files": [
-    "dist",
-    "src",
-    "package.json",
-    "tsconfig.json"
+    "dist"
   ],
   "license": "GPL-3.0",
   "prettier": {


### PR DESCRIPTION
This pull request makes a small change to the `package.json` file, updating the `files` array to only include the `dist` directory. This means only built files will be published, reducing the package size and excluding source and configuration files from the published package.