### PR TITLE
build: emit sourcemaps for CJS and ESM builds

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,10 @@
     "noEmitOnError": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "declaration": true
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "inlineSources": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
## Summary
- Enables `sourceMap`, `declarationMap`, and `inlineSources` in `tsconfig.base.json`, so both CJS and ESM builds emit `.js.map` / `.d.ts.map` files with TypeScript source embedded.
- Maps ship inside `npm pack` automatically — `files: ["dist"]` already covers them; no `files` or `.npmignore` change needed.
- Tarball unpacked size grows from ~78 KB to ~142 KB (gzipped: 28 KB) — driven by inlined sources.

## Why inlineSources
We publish only `dist/` (not `src/`), so external `sources` paths in the .map files would be dangling on consumers' machines. Inlining the TS source into `sourcesContent` is the standard fix for libraries and makes sourcemaps self-contained.

## Verification
- Clean rebuild produces `.js.map` + `.d.ts.map` for every `.js` / `.d.ts` in both `dist/cjs/` and `dist/esm/`.
- Each emitted `.js` ends with `//# sourceMappingURL=...map`.
- `sourcesContent[0]` in the map files contains the full TS source.
- `npm pack --dry-run` lists 16 map files in the tarball.
- With `node --enable-source-maps`, a thrown error from a built CJS/ESM entrypoint resolves to `src/NtpTimeSync.ts:<line>` (verified locally).
- CJS and ESM integration tests still pass; `examples/example.js` still runs.

## Test plan
- [x] CI green across Node 20/22/24/25 matrix (build + CJS + ESM integration).
- [x] Deno matrix still green.
- [x] Prettier workflow still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)