### PR TITLE
build: ignore yarn lock/state files from vcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ typings/
 /dist/
 /.idea/
 yarn.lock
+/.pnp.cjs
+/.yarn/install-state.gz


### PR DESCRIPTION
ignore yarn lock/state files from vcs